### PR TITLE
Remove pinned version from README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Terraform module for Cloudbase on GCP.
 ```
 module "cloudbase" {
   source  = "Levetty/cloudbase/google"
-  version = "0.6.1"
 
   project_id = "xxx" # required
 


### PR DESCRIPTION
## Summary
- Remove the `version = "0.6.1"` line from the README usage example.

## Changes
- `README.md`: dropped the pinned version from the `module "cloudbase"` block.